### PR TITLE
(polls) Renaming

### DIFF
--- a/react/features/polls/components/AbstractPollAnswerDialog.js
+++ b/react/features/polls/components/AbstractPollAnswerDialog.js
@@ -71,7 +71,7 @@ const AbstractPollAnswerDialog = (Component: AbstractComponent<AbstractProps>) =
         const answerData = {
             attributes: {
                 pollId,
-                senderId: localId,
+                voterId: localId,
                 voterName: localName
             },
             children: checkBoxStates.map(checkBoxState => {

--- a/react/features/polls/components/AbstractPollCreateDialog.js
+++ b/react/features/polls/components/AbstractPollCreateDialog.js
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
 
+import { getParticipantDisplayName } from '../../base/participants';
 import { COMMAND_NEW_POLL } from '../constants';
 
 /*
@@ -67,6 +68,9 @@ const AbstractPollCreateDialog = (Component: AbstractComponent<AbstractProps>) =
     });
 
     const conference = useSelector(state => state['features/base/conference'].conference);
+    const myId = conference.myUserId();
+    const myName = useSelector(state => getParticipantDisplayName(state, myId));
+
 
     const onSubmit = useCallback(() => {
         const filteredAnswers = answers.filter(answer => answer.trim().length > 0);
@@ -78,7 +82,8 @@ const AbstractPollCreateDialog = (Component: AbstractComponent<AbstractProps>) =
         conference.sendCommandOnce(COMMAND_NEW_POLL, {
             attributes: {
                 pollId: Math.floor(Math.random() * Number.MAX_SAFE_INTEGER),
-                senderId: conference.myUserId(),
+                senderId: myId,
+                senderName: myName,
                 question
             },
             children: filteredAnswers.map(answer => {

--- a/react/features/polls/middleware.js
+++ b/react/features/polls/middleware.js
@@ -20,7 +20,7 @@ MiddlewareRegistry.register(({ dispatch, getState }) => next => action => {
         const { poll, pollId, queue } = action;
 
         const state = getState();
-        const senderName = getParticipantDisplayName(state, poll.senderId);
+        const senderName = poll.senderName;
         const localParticipant = getLocalParticipant(state);
         const localName = getParticipantDisplayName(state, localParticipant.id);
         const isLocal = poll.senderId === localParticipant.id;

--- a/react/features/polls/reducer.js
+++ b/react/features/polls/reducer.js
@@ -77,7 +77,7 @@ ReducerRegistry.register('features/polls', (state = INITIAL_STATE, action) => {
         for (let i = 0; i < newAnswers.length; i++) {
             // if the answer was chosen, we add the sender to the set of voters of this answer
             if (answer.answers[i] === true) {
-                newAnswers[i].voters.set(answer.senderId, answer.voterName);
+                newAnswers[i].voters.set(answer.voterId, answer.voterName);
             }
         }
 

--- a/react/features/polls/subscriber.js
+++ b/react/features/polls/subscriber.js
@@ -16,6 +16,7 @@ StateListenerRegistry.register(
             conference.addCommandListener(COMMAND_NEW_POLL, ({ attributes, children }) => {
                 const poll = {
                     senderId: attributes.senderId,
+                    senderName: attributes.senderName,
                     answered: false,
                     question: attributes.question,
                     answers: children.map(answerData => {

--- a/react/features/polls/subscriber.js
+++ b/react/features/polls/subscriber.js
@@ -12,9 +12,9 @@ const parsePollData = pollData => {
     if (typeof pollData !== 'object' || pollData === null) {
         return null;
     }
-    const { id, senderId, question, answers } = pollData;
+    const { id, senderId, senderName, question, answers } = pollData;
 
-    if (typeof id !== 'string' || typeof senderId !== 'string'
+    if (typeof id !== 'string' || typeof senderId !== 'string' || typeof senderName !== 'string'
         || typeof question !== 'string' || !(answers instanceof Array)) {
         return null;
     }
@@ -39,6 +39,7 @@ const parsePollData = pollData => {
 
     return {
         senderId,
+        senderName,
         question,
         answered: true,
         answers: answers2

--- a/react/features/polls/subscriber.js
+++ b/react/features/polls/subscriber.js
@@ -36,10 +36,10 @@ StateListenerRegistry.register(
             // Command triggered when new answer is received
             conference.addCommandListener(COMMAND_ANSWER_POLL, ({ attributes, children }) => {
                 const { dispatch } = store;
-                const { senderId, voterName, pollId } = attributes;
+                const { voterId, voterName, pollId } = attributes;
 
                 const receivedAnswer: Answer = {
-                    senderId,
+                    voterId,
                     voterName,
                     pollId: parseInt(pollId, 10),
                     answers: children.map(

--- a/react/features/polls/types.js
+++ b/react/features/polls/types.js
@@ -3,9 +3,9 @@
 export type Answer = {
 
     /**
-     * ID of the sender of this poll
+     * ID of the voter for this answer
      */
-    senderId: string,
+    voterId: string,
 
     /**
      * Name of the voter

--- a/react/features/polls/types.js
+++ b/react/features/polls/types.js
@@ -30,6 +30,13 @@ export type Poll = {
      */
     senderId: string,
 
+
+    /**
+     * Name of the sender of this poll
+     * Allows to know send Name even if he quits the call
+     */
+    senderName: string,
+
     /**
      * If the participant has answered the poll
      */

--- a/react/features/polls/types.js
+++ b/react/features/polls/types.js
@@ -33,7 +33,7 @@ export type Poll = {
 
     /**
      * Name of the sender of this poll
-     * Allows to know send Name even if he quits the call
+     * Store poll sender name in case they exit the call
      */
     senderName: string,
 

--- a/resources/prosody-plugins/mod_polls.lua
+++ b/resources/prosody-plugins/mod_polls.lua
@@ -56,6 +56,7 @@ module:hook("message/bare", function(event)
 		local poll = {
 			id = data.pollId,
 			sender_id = data.senderId,
+			sender_name = data.senderName,
 			question = data.question,
 			answers = answers
 		};
@@ -73,7 +74,7 @@ module:hook("message/bare", function(event)
 
 		for i, value in ipairs(data.answers) do
 			if value then
-				poll.answers[i].voters[data.senderId] = data.voterName;
+				poll.answers[i].voters[data.voterId] = data.voterName;
 			end
 		end
 	end
@@ -92,6 +93,7 @@ module:hook("muc-occupant-joined", function(event)
 		data.polls[i] = {
 			id = poll.id,
 			senderId = poll.sender_id,
+			senderName = poll.sender_name,
 			question = poll.question,
 			answers = poll.answers
 		};


### PR DESCRIPTION
Various renaming to sanitize conventions used in polls code base.

-> voters are now clearly distinct from sender (poll sender)
-> senderName is now passed with polls to allow continuing displaying original senders' name even if they quit.