### PR TITLE
Switch to using ENDPOINT_MESSAGE and NON_PARTICIPANT_MESSAGE events

### DIFF
--- a/react/features/polls/subscriber.js
+++ b/react/features/polls/subscriber.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { getCurrentConference } from '../base/conference';
+import { JitsiConferenceEvents } from '../base/lib-jitsi-meet';
 import { StateListenerRegistry } from '../base/redux';
 import {
     NOTIFICATION_TIMEOUT,
@@ -56,7 +57,7 @@ StateListenerRegistry.register(
     state => getCurrentConference(state),
     (conference, store, previousConference) => {
         if (conference && conference !== previousConference) {
-            conference.room.addListener('xmmp.json_message_received', (senderJid, data) => {
+            const receiveMessage = (_, data) => {
                 if (data.type === COMMAND_NEW_POLL) {
                     const { question, answers, pollId, senderId, senderName } = data;
 
@@ -106,7 +107,9 @@ StateListenerRegistry.register(
                         }
                     }
                 }
-            });
+            };
+            conference.on(JitsiConferenceEvents.ENDPOINT_MESSAGE_RECEIVED, receiveMessage);
+            conference.on(JitsiConferenceEvents.NON_PARTICIPANT_MESSAGE_RECEIVED, receiveMessage);
         }
     }
 );


### PR DESCRIPTION
Since "xmmp.json_message_received" is an event internal to lib-jitsi-meet, it would be better to use events from the public API. To cover the use cases that JitsiConferenceEvents.ENDPOINT_MESSAGE_RECEIVED doesn't cover, a new event will be added to LJM (cf. [this PR](https://github.com/jitsi/lib-jitsi-meet/pull/1671)).

This should not be merged until the corresponding changes to LJM have been merged.