### PR TITLE
Disable send poll button is the poll creation form can't be submitted

### DIFF
--- a/react/features/polls/components/AbstractPollCreate.js
+++ b/react/features/polls/components/AbstractPollCreate.js
@@ -28,6 +28,7 @@ export type AbstractProps = InputProps & {
     moveAnswer: (number, number) => void,
     removeAnswer: number => void,
     onSubmit: Function,
+    isSubmitDisabled: boolean,
     t: Function,
 };
 
@@ -109,11 +110,17 @@ const AbstractPollCreate = (Component: AbstractComponent<AbstractProps>) => (pro
 
     }, [ conference, question, answers ]);
 
+    // Check if the poll create form can be submitted i.e. if the send button should be disabled.
+    const isSubmitDisabled
+        = question.trim().length <= 0 // If no question is provided
+        || answers.filter(answer => answer.trim().length > 0).length < 2; // If not enough options are provided
+
     const { t } = useTranslation();
 
     return (<Component
         addAnswer = { addAnswer }
         answers = { answers }
+        isSubmitDisabled = { isSubmitDisabled }
         moveAnswer = { moveAnswer }
         onSubmit = { onSubmit }
         question = { question }

--- a/react/features/polls/components/native/PollCreate.js
+++ b/react/features/polls/components/native/PollCreate.js
@@ -16,6 +16,7 @@ const PollCreate = (props: AbstractProps) => {
     const {
         addAnswer,
         answers,
+        isSubmitDisabled,
         onSubmit,
         question,
         removeAnswer,
@@ -163,6 +164,7 @@ const PollCreate = (props: AbstractProps) => {
 
                 <Button
                     color = '#17a0db'
+                    disabled = { isSubmitDisabled }
                     mode = 'contained'
                     onPress = { onSubmit }
                     style = { chatStyles.pollCreateButton } >

--- a/react/features/polls/components/web/PollCreate.js
+++ b/react/features/polls/components/web/PollCreate.js
@@ -14,6 +14,7 @@ const PollCreate = (props: AbstractProps) => {
     const {
         addAnswer,
         answers,
+        isSubmitDisabled,
         moveAnswer,
         onSubmit,
         question,
@@ -161,6 +162,7 @@ const PollCreate = (props: AbstractProps) => {
                     onInput = { autogrow }
                     onKeyDown = { onQuestionKeyDown }
                     placeholder = { t('polls.create.questionPlaceholder') }
+                    required = { true }
                     row = '1'
                     value = { question } />
             </div>
@@ -181,6 +183,7 @@ const PollCreate = (props: AbstractProps) => {
                                 onKeyDown = { ev => onAnswerKeyDown(i, ev) }
                                 placeholder = { t('polls.create.answerPlaceholder', { index: i + 1 }) }
                                 ref = { r => registerFieldRef(i, r) }
+                                required = { true }
                                 row = { 1 }
                                 value = { answer } />
                             <button
@@ -228,6 +231,7 @@ const PollCreate = (props: AbstractProps) => {
             <button
                 aria-label = { t('polls.create.send') }
                 className = 'poll-small-primary-button'
+                disabled = { isSubmitDisabled }
                 type = 'submit' >
                 <span>{t('polls.create.send')}</span>
             </button>


### PR DESCRIPTION
Improve UX with a disabled send poll button when not enough data is provided in the form
